### PR TITLE
Using https instead of http

### DIFF
--- a/src/main/resources/templates/auth0ShiroLogin.html
+++ b/src/main/resources/templates/auth0ShiroLogin.html
@@ -168,7 +168,7 @@
         <script src="../static/vendors/jquery-validation/jquery.validate.min.js" th:src="@{/vendors/jquery-validation/jquery.validate.min.js}"></script>
         <script src="../static/js/validation/custom.min.js" th:src="@{/js/validation/custom.min.js}"></script>
         <script src="../static/js/login.min.js" th:src="@{/js/login.min.js}"></script>
-        <script src="http://cdn.auth0.com/js/lock/10.7.2/lock.min.js"></script>
+        <script src="https://cdn.auth0.com/js/lock/10.7.2/lock.min.js"></script>
         <script type="text/javascript" th:inline="javascript">
                                     var auth0ClientId = /*[[${@environment.getProperty('auth0.clientId')}]]*/ '';
                                     var auth0Domain = /*[[${@environment.getProperty('auth0.domain')}]]*/ '';


### PR DESCRIPTION
When I deployed the causal-web on AWS, auth0 didn't work. And it turned out that we are using the cdn auth0 Lock javascript file over http instead of https.

This PR fixed this small bug by using the cdn js over https. We didn't notice this bug during testing on PSC is because PSC didn't enable the auth0 profile.

Since @kvb2univpitt is on vacation, @espinoj can you merge this PR? Thanks!